### PR TITLE
Fixes 500 error on a request for a directory.

### DIFF
--- a/andrew_server.go
+++ b/andrew_server.go
@@ -83,8 +83,19 @@ func ParseArgs(args []string) (string, string, string) {
 func (a AndrewServer) Serve(w http.ResponseWriter, r *http.Request) {
 	pagePath := path.Clean(r.RequestURI)
 
-	if strings.HasSuffix(pagePath, "/") {
+	// Ensure the pagePath is relative to the root of a.SiteFiles.
+	// This involves trimming a leading slash if present.
+	pagePath = strings.TrimPrefix(pagePath, "/")
+
+	maybeDir, _ := fs.Stat(a.SiteFiles, pagePath)
+
+	switch {
+	case maybeDir != nil && maybeDir.IsDir():
+		pagePath = pagePath + "/index.html"
+	case strings.HasSuffix(pagePath, "/"):
 		pagePath = pagePath + "index.html"
+	case pagePath == "":
+		pagePath = pagePath + "/index.html"
 	}
 
 	if isIndexPage(pagePath) {

--- a/andrew_server_test.go
+++ b/andrew_server_test.go
@@ -161,6 +161,45 @@ func TestGetPagesWithoutSpecifyingPageDefaultsToIndexHtml(t *testing.T) {
 	}
 }
 
+func TestGettingADirectoryDefaultsToIndexHtml(t *testing.T) {
+	t.Parallel()
+
+	expected := []byte(`
+<!DOCTYPE html>
+<head>
+<title>index title</title>
+</head>
+<body>
+</body>
+	`)
+
+	contentRoot := t.TempDir()
+	os.MkdirAll(contentRoot+"/pages", 0o755)
+
+	// fstest.MapFS does not create directory-like objects, so we need a real file system in this test.
+	err := os.WriteFile(contentRoot+"/pages/index.html", expected, 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testUrl := startAndrewServer(t, os.DirFS(contentRoot))
+
+	resp, err := http.Get(testUrl + "/pages/")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	received, err := io.ReadAll(resp.Body)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(received, expected) {
+		t.Fatalf("Expected %q, received %q", expected, received)
+	}
+}
+
 func TestGetPagesCanRetrieveOtherPages(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The cleaning of the requestURI was removing the trailing slash in all cases except for requesting the root of the site. I made the testing a little more consistent, and in some cases now explicitly check whether the thing being requested is a directory inside the fs.FS